### PR TITLE
removing snowflakecomputing.com from account

### DIFF
--- a/soda/snowflake/soda/data_sources/snowflake_data_source.py
+++ b/soda/snowflake/soda/data_sources/snowflake_data_source.py
@@ -101,7 +101,7 @@ class SnowflakeDataSource(DataSource):
             user=self.user,
             password=self.password,
             token=self.token,
-            account=self.account,
+            account=re.sub(r'\.snowflakecomputing\.com(\/)*$','',self.account),
             data_source=self.data_source,
             database=self.database,
             schema=self.schema,


### PR DESCRIPTION
Snowflake connections are failing during data profiling.

As per https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api, the account name that is being passed should not include the domain name snowflakecomputing.com. 

A fix has been made to remove the suffix snowflakecomputing.com from account name if its present.

Associated linear: https://linear.app/atlanproduct/issue/PES-356/dr-martens-20-or-profiling-workflow-is-not-updating-as-expected

Logs: 
` WARNING connectionpool - urlopen: Retrying (Retry(total=0, connect=None, read=None, redire
ct=None, status=None)) after connection broken by 'NewConnectionError('<snowflake.connector.vendored.urllib3.conne
ction.HTTPSConnection object at 0x7f95aab87760>: Failed to establish a new connection: [Errno -2] Name or service
not known')': /.snowflakecomputing.com:443/session/v1/login-request?request_id=d1813e16-5448-4bdf-8814-c0f2e064e50
9&databaseName=PRESENTATION&schemaName=PRESENTATION&warehouse=COMPUTE_WH&roleName=ATLAN_USER_ROLE `