### PR TITLE
add support for externalId for athena connection

### DIFF
--- a/soda/athena/soda/data_sources/athena_data_source.py
+++ b/soda/athena/soda/data_sources/athena_data_source.py
@@ -34,6 +34,7 @@ class AthenaDataSource(DataSource):
             session_token=data_source_properties.get("session_token"),
             region_name=data_source_properties.get("region_name"),
             profile_name=data_source_properties.get("profile_name"),
+            external_id=data_source_properties.get("external_id")
         )
 
     def connect(self):
@@ -45,6 +46,7 @@ class AthenaDataSource(DataSource):
                 s3_staging_dir=self.athena_staging_dir,
                 region_name=self.aws_credentials.region_name,
                 role_arn=self.aws_credentials.role_arn,
+                external_id=self.aws_credentials.external_id,
                 catalog_name=self.catalog,
                 work_group=self.work_group,
                 schema_name=self.schema,

--- a/soda/core/soda/common/aws_credentials.py
+++ b/soda/core/soda/common/aws_credentials.py
@@ -12,10 +12,12 @@ class AwsCredentials:
         session_token: Optional[str] = None,
         profile_name: Optional[str] = None,
         region_name: Optional[str] = "eu-west-1",
+        external_id: Optional[str] = None,
     ):
         self.access_key_id = access_key_id
         self.secret_access_key = secret_access_key
         self.role_arn = role_arn
+        self.external_id = external_id
         self.session_token = session_token
         self.profile_name = profile_name
         self.region_name = region_name
@@ -32,6 +34,7 @@ class AwsCredentials:
             access_key_id=access_key_id,
             secret_access_key=configuration.get("secret_access_key"),
             role_arn=configuration.get("role_arn"),
+            external_id=configuration.get("external_id"),
             session_token=configuration.get("session_token"),
             profile_name=configuration.get("profile_name"),
             region_name=configuration.get("region", "eu-west-1"),


### PR DESCRIPTION
soda-core natively does not support externalId during authentication for athena. They don't list it as a property in their official docs: https://docs.soda.io/soda/connect-athena.html

Internally the library uses pyathena to connect which does support this. So we just need to add the property to the class and pass it. 

I've tested this on pes tenant here: https://pes-new.atlan.dev/api/orchestration/workflows/default/athenaaaaa-profiling-gwr8q?tab=workflow&nodeId=athenaaaaa-profiling-gwr8q-3922066610&nodePanelView=summary&uid=e7c3aec3-e1a3-4a20-8c2b-3cb3e85a32e8

I added these changes along with that, created an image for marketplace scripts to use and and passed that to the workflow to use in order to verify.

Jira: https://atlanhq.atlassian.net/browse/PES-1847