### PR TITLE
PES-3645 Soda <> Redshift IAM Role profiling

### DIFF
--- a/soda/core/soda/common/aws_credentials.py
+++ b/soda/core/soda/common/aws_credentials.py
@@ -58,7 +58,7 @@ class AwsCredentials:
             aws_session_token=self.session_token,
         )
 
-        assumed_role_object = self.sts_client.assume_role(RoleArn=self.role_arn, RoleSessionName=role_session_name)
+        assumed_role_object = self.sts_client.assume_role(RoleArn=self.role_arn, ExternalId=self.external_id, RoleSessionName=role_session_name)
         credentials_dict = assumed_role_object["Credentials"]
         return AwsCredentials(
             region_name=self.region_name,

--- a/soda/redshift/soda/data_sources/redshift_data_source.py
+++ b/soda/redshift/soda/data_sources/redshift_data_source.py
@@ -22,6 +22,9 @@ class RedshiftDataSource(DataSource):
         self.connect_timeout = data_source_properties.get("connection_timeout_sec")
         self.username = data_source_properties.get("username")
         self.password = data_source_properties.get("password")
+        self.dbuser = data_source_properties.get("dbuser")
+        self.dbname = data_source_properties.get("dbname")
+        self.cluster_id = data_source_properties.get("cluster_id")
 
         if not self.username or not self.password:
             aws_credentials = AwsCredentials(
@@ -31,6 +34,7 @@ class RedshiftDataSource(DataSource):
                 session_token=data_source_properties.get("session_token"),
                 region_name=data_source_properties.get("region", "eu-west-1"),
                 profile_name=data_source_properties.get("profile_name"),
+                external_id=data_source_properties.get("external_id"),
             )
             self.username, self.password = self.__get_cluster_credentials(aws_credentials)
 
@@ -60,9 +64,9 @@ class RedshiftDataSource(DataSource):
             aws_session_token=resolved_aws_credentials.session_token,
         )
 
-        cluster_name = self.host.split(".")[0]
-        username = self.username
-        db_name = self.database
+        cluster_name = self.cluster_id if self.cluster_id else self.host.split(".")[0]
+        username = self.dbuser if self.dbuser else self.username
+        db_name = self.dbname if self.dbname else self.database
         cluster_creds = client.get_cluster_credentials(
             DbUser=username, DbName=db_name, ClusterIdentifier=cluster_name, AutoCreate=False, DurationSeconds=3600
         )


### PR DESCRIPTION
## Change Summary

Adding support for Soda profiling w Redshift iam role.
We're now sending a few more attributes to the soda-core in case of Iam role setup. 
Why? please check the RCA below.

Packages PR: https://github.com/atlanhq/marketplace-packages/pull/12019

## Initial Problem

we were getting the error from the boto library stating partial creds are provided

```
botocore.exceptions.PartialCredentialsError: Partial credentials found in explicit, missing: aws_access_key_id
reason: somehow, the secret (password) was saved in the creds and the access key wasn’t there - hence, the partial creds error
```

to fix this, in the sodaConnectionTemplate, we updated the logic to ensure that with IAM role only ARN is sent to the boto library, allowing it to assume the role correctly

## Problems while assuming the role
```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::015006955552:assumed-role/mercuryins-nodeinstance-role/i-09cee7739ceea8335 
is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::725205928352:role/mig-pr-ebi-atlan-external-role
```

reason: we are supposed to send the ARN as well as the ExternalId to boto so the role can be assumed (if External_Id is used by the user)

## Problems during the [get_cluster_credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/redshift/client/get_cluster_credentials.html) call
```
| botocore.exceptions.ParamValidationError: Parameter validation failed:
| Invalid type for parameter DbUser, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
reason: get_cluster_credentials expected a dbuser as well dbname for the request - we were passing null to it
```
reason: get_cluster_credentials expected a dbuser as well dbname for the request - we were passing null to it
& because we were not passing it initially, we had to update the sodaConnectionTemplate to use these attributes (we already ask for these details in the Redshift crawler setup)

this still failed stating a policy issue
```
| botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the GetClusterCredentials operation: 
User: arn:aws:sts::725205928352:assumed-role/mig-pr-ebi-atlan-external-role/soda_redshift_get_cluster_credentials is not authorized to perform: redshift:GetClusterCredentials
on resource: arn:aws:redshift:eu-west-1:725205928352:dbuser:mercury/atlan_user because no identity-based policy allows the redshift:GetClusterCredentials action
```
reason: if we look closely, we’re passing the region as `eu-west-1` (which is the default region) and we’re seeing the `cluster_name` as `mercury` (which we're getting after resolving the host name)
to fix this, pass the cluster id as well as ask for the cluster region in the Redshift config

## Jira Issues Resolved

https://atlanhq.atlassian.net/browse/PES-3645
