### PR TITLE
feat: make profile column limits configurable via SodaCL

### DIFF
--- a/soda/core/soda/sodacl/data_source_check_cfg.py
+++ b/soda/core/soda/sodacl/data_source_check_cfg.py
@@ -21,9 +21,8 @@ class ProfileColumnsCfg(DataSourceCheckCfg):
         super().__init__(data_source_name, location)
         self.include_columns: List[str] = []
         self.exclude_columns: List[str] = []
-        # TODO add parsing for this configuration
+        # Defaults; overridable via the "profile columns" section in SodaCL
         self.limit_mins_maxs: int = 5
-        # TODO add parsing for this configuration
         self.limit_frequent_values: int = 10
 
 

--- a/soda/core/soda/sodacl/sodacl_parser.py
+++ b/soda/core/soda/sodacl/sodacl_parser.py
@@ -1535,6 +1535,19 @@ class SodaCLParser(Parser):
         data_source_scan_cfg = self.get_data_source_scan_cfgs()
         data_source_scan_cfg.add_data_source_cfg(profile_columns_cfg)
 
+        # Optional overrides for profiling limits; fall back to ProfileColumnsCfg defaults.
+        for limit_key in ("limit_frequent_values", "limit_mins_maxs"):
+            limit_value = header_content.get(limit_key)
+            if limit_value is None:
+                continue
+            if isinstance(limit_value, int) and not isinstance(limit_value, bool) and limit_value > 0:
+                setattr(profile_columns_cfg, limit_key, limit_value)
+            else:
+                self.logs.error(
+                    f'"{limit_key}" must be a positive integer in profile columns',
+                    location=profile_columns_cfg.location,
+                )
+
         columns = header_content.get("columns")
         if isinstance(columns, list):
             for column_expression in columns:


### PR DESCRIPTION
## What

Parse two optional keys in the `profile columns` SodaCL section:

- `limit_frequent_values` — top-N frequent (categorical) values captured per column
- `limit_mins_maxs` — N mins/maxs captured per numeric column

Both fall back to the existing `ProfileColumnsCfg` defaults (`10` and `5`) when omitted, so behavior is unchanged for callers that don't set them. Invalid values (non-int / non-positive) are logged as a parse error.

## Why

These fields already existed on `ProfileColumnsCfg` but carried `# TODO add parsing for this configuration` — they were hardcoded and only changeable by forking. Downstream profiling (Atlan marketplace-scripts) needs to raise `limit_frequent_values` to populate richer categorical values for conversational/semantic search, without re-releasing the fork for every tweak.

## Notes

- Pure parser/config change; the limits were already plumbed through to the SQL (`profiling_sql_values_frequencies_query`) and profilers.
- No change to default output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)